### PR TITLE
RemoteServiceException$ForegroundServiceDidNotStopInTimeException

### DIFF
--- a/android/src/main/java/com/supersami/foregroundservice/ForegroundService.java
+++ b/android/src/main/java/com/supersami/foregroundservice/ForegroundService.java
@@ -331,4 +331,11 @@ public class ForegroundService extends Service {
             }, delay);
         }
     }
+
+    @Override
+    public void onTimeout(int type, int reason) {
+        Log.d("ForegroundService", "FGS timed out. Type: " + type + " Reason: " + reason);
+        stopForeground(true);
+        stopSelf();
+    }
 }


### PR DESCRIPTION
FGS was crashing on API 14+ when the timeout limit was reached because the service wasn’t stopping itself after onTimeout() was invoked, leading to a RemoteServiceException. https://developer.android.com/develop/background-work/services/fgs/timeout

This change implements onTimeout() and calls stopForeground() + stopSelf() immediately to prevent the crash and align with Android’s expected behavior.